### PR TITLE
Fixed assertValue(null) scenario

### DIFF
--- a/library/src/main/java/tmg/testutils/livedata/LiveDataTestScope.kt
+++ b/library/src/main/java/tmg/testutils/livedata/LiveDataTestScope.kt
@@ -53,7 +53,7 @@ class LiveDataTestScope<T>(
      *  the live data matches exactly
      */
     fun assertValue(expected: T) {
-        assertNotNull(latestValue)
+        assertTrue(listOfValues.size >= 1, "No value found at latest position")
         assertEquals(expected, latestValue)
     }
 

--- a/library/src/test/java/tmg/testutils/livedata/LiveDataTestScopeTest.kt
+++ b/library/src/test/java/tmg/testutils/livedata/LiveDataTestScopeTest.kt
@@ -58,12 +58,33 @@ internal class LiveDataTestScopeTest: BaseTest() {
         }
 
         @Test
+        fun `throws equal exception if no item has emitted yet value supports null`() {
+            initSUT()
+            assertThrows<AssertionError> {
+                sut.liveDataNullable.test {
+                    assertValue(Model("my-id"))
+                }
+            }
+        }
+
+        @Test
         fun `doesnt throw error when models match`() {
             initSUT()
             sut.liveData.value = Model("hey")
             assertDoesNotThrow {
                 sut.liveData.test {
                     assertValue(Model("hey"))
+                }
+            }
+        }
+
+        @Test
+        fun `doesnt throw error when model is null but is explicitly assigned`() {
+            initSUT()
+            sut.liveDataNullable.value = null
+            assertDoesNotThrow {
+                sut.liveDataNullable.test {
+                    assertValue(null)
                 }
             }
         }


### PR DESCRIPTION
When the live data generic is a nullable type using `assertValue(null)` will fail because there an explicit null check (which was originally the check for if `listOfValues` contains an item. This is inaccurate and means that `assertValue(null)` can never be used. 

Assertion changed to check the list of the values emitted from the live data instance, so `assertValue(null)` is a valid assertion to make